### PR TITLE
Doc precision on DataSet.max(): compares only numeric values

### DIFF
--- a/docs/data/dataset.html
+++ b/docs/data/dataset.html
@@ -342,7 +342,7 @@ var data = new vis.DataSet([data] [, options])
       <td>max(field)</td>
       <td>Object | null</td>
       <td>
-        Find the item with maximum value of specified field. Returns <code>null</code> if no item is found.
+        Find the item with maximum numeric value of specified field. Returns <code>null</code> if no item is found, or if none of the found items has a numeric value.
       </td>
     </tr>
 


### PR DESCRIPTION
Just a precision in the doc about max(): only numeric field values may be compared.